### PR TITLE
Make app visible only to owners

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,12 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   helper_method :current_user, :signed_in?
 
+  # Keep out of our demo! :)
+  http_basic_authenticate_with(
+    name: ENV.fetch("LOGIN_NAME"),
+    password: ENV.fetch("LOGIN_PASSWORD")
+  ) if Rails.env.production?
+
   def current_user
     @current_user ||= User.find_by(email: session[:current_user])
   end


### PR DESCRIPTION
@exalted here we go! 

I enabled the authentication on production only: both development and test shouldn’t be aware of this temporary solution.
