### PR TITLE
Put badges on README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+task-planner-web [![Build Status](https://travis-ci.org/task-planner/task-planner-web.svg?branch=master)](https://travis-ci.org/task-planner/task-planner-web) [![Code Climate](https://codeclimate.com/github/task-planner/task-planner-web.png)](https://codeclimate.com/github/task-planner/task-planner-web)
+================


### PR DESCRIPTION
Specifically:
- Code Climate
- Travis Build Status

It looks [like this](https://github.com/task-planner/task-planner-web/blob/badges/README.md).
