### PR TITLE
Disable card actions (e.g., archive, preview) when a card is archived

### DIFF
--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -19,10 +19,12 @@
   </header>
 
   <div class="card-actions-container clearfix">
+    <% unless @card.archived? %>
     <div class="buttons-container clearfix">
       <%= render "cards/archive", card: @card %>
       <%= render "cards/preview", card: @card %>
     </div>
+    <% end %>
 
     <div class="preview-container clearfix">
       <% if @card.previewing? %>


### PR DESCRIPTION
[View on catchup](http://catchup.io/boards/3/cards/63)