### PR TITLE
Drag & drop to reoder cards doesn’t work properly

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -9,7 +9,7 @@ class Card < ActiveRecord::Base
   belongs_to :list
   delegate :board, to: :list
 
-  ranks :position, with_same: :list_id
+  ranks :position, with_same: :list_id, scope: :unarchived
 
   validates :title, presence: true
 


### PR DESCRIPTION
[View on catchup](http://catchup-web-ifqtnfmy.herokuapp.com/boards/3/cards/177)

We kinda knew this, but recently I am noticing even more so often when I drag & drop a card to prioritize it usually doesn’t actually save its correct position, instead if you reload the page, it is placed in wrong position.

This needs a fix.