### PR TITLE
PR descriptions are cut off

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -65,7 +65,7 @@ class Card < ActiveRecord::Base
 
     uri = build_repository_uri
     uri.path += "compare/#{branch_name}"
-    uri.query = "expand=1&title=#{title}&body=#{pr_body}"
+    uri.query = "expand=1&title=#{CGI.escape(title)}&body=#{CGI.escape(pr_body)}"
     uri.to_s
   end
 

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -60,8 +60,9 @@ class Card < ActiveRecord::Base
   end
 
   def compare_url(card_url)
-    pr_body = "[View on catchup](#{card_url})"
-    pr_body += "\n\n#{description}" if description.present?
+    pr_body = ""
+    pr_body += "#{description}\n\n" if description.present?
+    pr_body += "--\n[Open card on Catchup](#{card_url})"
 
     uri = build_repository_uri
     uri.path += "compare/#{branch_name}"

--- a/app/views/card_mailer/card_archived.html.erb
+++ b/app/views/card_mailer/card_archived.html.erb
@@ -2,6 +2,6 @@
 
 <p>&ndash;</p>
 <p>
-  <%= link_to "See this card on catchup", board_card_url(@board, @card) %>
+  <%= link_to "See this card on Catchup", board_card_url(@board, @card) %>
   to reply.
 </p>

--- a/app/views/card_mailer/card_moved.html.erb
+++ b/app/views/card_mailer/card_moved.html.erb
@@ -2,6 +2,6 @@
 
 <p>&ndash;</p>
 <p>
-  <%= link_to "See this card on catchup", board_card_url(@board, @card) %>
+  <%= link_to "See this card on Catchup", board_card_url(@board, @card) %>
   to reply.
 </p>

--- a/app/views/card_mailer/card_previewed.html.erb
+++ b/app/views/card_mailer/card_previewed.html.erb
@@ -5,6 +5,6 @@
 
 <p>&ndash;</p>
 <p>
-  <%= link_to "See this card on catchup", board_card_url(@board, @card) %>
+  <%= link_to "See this card on Catchup", board_card_url(@board, @card) %>
   to reply.
 </p>

--- a/app/views/card_mailer/new_card.html.erb
+++ b/app/views/card_mailer/new_card.html.erb
@@ -2,6 +2,6 @@
 
 <p>&ndash;</p>
 <p>
-  <%= link_to "See this card on catchup", board_card_url(@board, @card) %>
+  <%= link_to "See this card on Catchup", board_card_url(@board, @card) %>
   to reply.
 </p>

--- a/app/views/comment_mailer/new_comment.html.erb
+++ b/app/views/comment_mailer/new_comment.html.erb
@@ -4,6 +4,6 @@
 
 <p>&ndash;</p>
 <p>
-  <%= link_to "See this card on catchup", board_card_url(@board, @card) %>
+  <%= link_to "See this card on Catchup", board_card_url(@board, @card) %>
   to reply.
 </p>


### PR DESCRIPTION
[View on catchup](http://catchup-web-ifqtnfmy.herokuapp.com/boards/3/cards/178)

When proposing a new PR's description through our GitHub button, descriptions are trimmed. The result looks pretty ugly and needs a fix.