### PR TITLE
"Ship it!” feature

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -46,6 +46,9 @@ class CardsController < ApplicationController
       head_branch
     )
 
+    @card.archive
+    CardObserver.publish(:card_archived, @card, current_user)
+
     flash[:success] = t("cards.shipit.success", card: @card.title)
     redirect_to @card.board
   rescue Octokit::Conflict

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -34,6 +34,30 @@ class CardsController < ApplicationController
     redirect_to [@card.board, @card]
   end
 
+  def shipit
+    @card = board.cards.find(params[:id])
+
+    base_branch = current_user.github.repo(board.title).default_branch
+    head_branch = @card.branch_name
+
+    current_user.github.merge(
+      @card.board.title,
+      base_branch,
+      head_branch
+    )
+
+    flash[:success] = t("cards.shipit.success", card: @card.title)
+    redirect_to @card.board
+  rescue Octokit::Conflict
+    flash[:error] = t("cards.shipit.merge-conflict", branch: head_branch)
+
+    redirect_to [@card.board, @card]
+  rescue Octokit::NotFound
+    flash[:error] = t("cards.shipit.not-found", branch: head_branch)
+
+    redirect_to [@card.board, @card]
+  end
+
   def update
     card = board.cards.find(params[:id])
     card.update_attributes(card_params)

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -40,11 +40,8 @@ class CardsController < ApplicationController
     base_branch = current_user.github.repo(board.title).default_branch
     head_branch = @card.branch_name
 
-    current_user.github.merge(
-      @card.board.title,
-      base_branch,
-      head_branch
-    )
+    current_user.github.merge(@card.board.title, base_branch, head_branch)
+    current_user.github.delete_branch(@card.board.title, head_branch)
 
     @card.archive
     CardObserver.publish(:card_archived, @card, current_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,13 +52,14 @@ class User < ActiveRecord::Base
     self.save!
   end
 
+  def github
+    @github_user ||= Octokit::Client.new(access_token: auth_token)
+  end
+
   private
 
   def github_repositories
     @github_repositories ||= github.repositories(nil, type: :public)
   end
 
-  def github
-    @github_user ||= Octokit::Client.new(access_token: auth_token)
-  end
 end

--- a/app/views/cards/_shipit.html.erb
+++ b/app/views/cards/_shipit.html.erb
@@ -1,0 +1,3 @@
+<%= form_for [:shipit, card.board, card], html: { class: 'preview-form clearfix' } do |f| %>
+  <%= button_tag t(".submit"), class: 'preview-button' %>
+<% end %>

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -24,6 +24,7 @@
     <div class="buttons-container clearfix">
       <%= render "cards/archive", card: @card %>
       <%= render "cards/preview", card: @card %>
+      <%= render "cards/shipit", card: @card %>
     </div>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,11 @@ en:
       submit: Archive
     preview:
       submit: Preview
+    shipit:
+      submit: Ship It!
+      not-found: Ooops! This card couldn't be shipped. Are you sure you already published a branch named `%{branch}` on this repository?
+      merge-conflict: Ooops! This card couldn't be shipped. Solve `%{branch}` conflicts first and retry!
+      success: Congratulations! You've just shipped %{card}!
   comments:
     create:
       error: There was an error while creating this comment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     resources :cards, only: [:create, :show, :update] do
       match :move, on: :member, via: [:patch, :put]
       match :archive, on: :member, via: [:patch, :put]
+      match :shipit, on: :member, via: [:patch, :put]
     end
   end
 


### PR DESCRIPTION
So we want a new shiny “Ship It!” button for each card and here’s the plan: once clicked, if GitHub doesn’t complain at all (meaning, branch’s merge status is green) it merges the branch on GitHub.

There’s a small catch though: if we merge branches, without caring much about PRs, then we wouldn’t necessarily know, which branch merge into, so I believe this is the best alternative scenario:

When “Ship It!” is clicked it will flash an error saying that there’s not PR open for that specific branch, and stop; otherwise go ahead and ask GitHub if PR is okay to merge (I don’t know no conflicting commits, tests are green, etc.) and merge.

Oh, and please use whatever flash status/message makes sense to give user feedback for things that happen in the “background”.

--
[Open card on Catchup](http://catchup.io/boards/3/cards/174)