### PR TITLE
Put colons on emoji image-alt

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,7 @@ module ApplicationHelper
 
     h(content).to_str.gsub(/:([\w+-]+):/) do |match|
       if emoji = Emoji.find_by_alias($1)
-        %(<img alt="#$1" src="#{image_url("emoji/#{emoji.image_filename}")}" style="vertical-align:middle; width: 20px; height: 20px" />)
+        %(<img alt=":#$1:" src="#{image_url("emoji/#{emoji.image_filename}")}" style="vertical-align:middle; width: 20px; height: 20px" />)
       else
         match
       end


### PR DESCRIPTION
So that quoting a previous answer through copy & pasting correctly renders the emoji.

--
[Open card on Catchup](http://catchup.io/boards/3/cards/186)